### PR TITLE
🍎 Allow opening search bar on Macs, via Cmd+F

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea/
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && (e.key === "f" || e.key === "F")) {
+      if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
         e.preventDefault();
         setSearchBarDisplayed(true);
       }


### PR DESCRIPTION
This PR adds support for the `Cmd` key for triggering the search bar.